### PR TITLE
feat: 新增 Hono middleware 支援 GCP trace context 自動關聯

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,163 @@
+# AGENTS.md - js-gcp-logger
+
+<project_overview>
+零配置 GCP 日誌整合，使用 `loglayer` + `pino`。
+- 生產環境：pino + @google-cloud/pino-logging-gcp-config
+- 開發環境：@loglayer/transport-simple-pretty-terminal
+
+結構簡單：`src/index.ts`（入口）+ `src/index.test.ts`（測試）
+</project_overview>
+
+<commands>
+## 建置 / 測試 / Lint 指令
+
+```bash
+npm run build              # tsc 編譯至 dist/
+npm test                   # vitest run（所有測試）
+npm run test:watch         # vitest（監控模式）
+npm run lint               # tsc --noEmit（類型檢查）
+
+# 單一測試檔案
+npx vitest run src/index.test.ts
+
+# 單一測試案例（依名稱）
+npx vitest run -t "應該建立 LogLayer 實例"
+```
+</commands>
+
+<typescript_rules>
+## TypeScript 規則
+
+配置：`strict: true`, `noUnusedLocals`, `noUnusedParameters`, `ES2022`, `ESNext`
+
+### 禁止
+- `as any`、`@ts-ignore`、`@ts-expect-error`（除非附註釋說明原因）
+- 空的 catch blocks
+- 未使用的變數或參數
+
+### 必須
+- 公開 API 須有明確類型定義
+- 物件形狀使用 `interface`（非 `type`，除非需要聯合型別）
+</typescript_rules>
+
+<code_style>
+## 程式碼風格
+
+### 匯入順序（空行分隔）
+```typescript
+// 1. 外部套件
+import { LogLayer } from 'loglayer'
+import pino from 'pino'
+
+// 2. 內部模組
+import { someUtil } from './utils'
+
+// 3. 類型匯入
+import type { ILogLayer } from 'loglayer'
+```
+
+### 命名慣例
+| 類型 | 慣例 | 範例 |
+|------|------|------|
+| 函式 | camelCase | `createLogger` |
+| 類型/介面 | PascalCase | `LoggerOptions` |
+| 檔案 | kebab-case | `index.ts` |
+| 測試 | `*.test.ts` | `index.test.ts` |
+
+### JSDoc（公開 API 必須）
+```typescript
+/**
+ * 建立 logger 實例
+ * @param options - Logger 的選用配置
+ * @returns 已配置的 Logger 實例
+ * @example
+ * const logger = createLogger()
+ * logger.info('Hello!')
+ */
+export function createLogger(options?: LoggerOptions): Logger
+```
+</code_style>
+
+<testing>
+## 測試規範
+
+框架：Vitest（globals 已啟用）
+
+### 結構範本
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+describe('createLogger', () => {
+  let originalEnv: NodeJS.ProcessEnv
+
+  beforeEach(() => {
+    originalEnv = { ...process.env }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    vi.restoreAllMocks()
+  })
+
+  it('應該建立 LogLayer 實例', () => { /* ... */ })
+})
+```
+
+### 命名格式
+使用中文：`應該 + 預期行為` 或 `當 X 時應 Y`
+```typescript
+it('應該建立 LogLayer 實例', () => {})
+it('當 NODE_ENV 為 production 時應使用生產環境傳輸', () => {})
+```
+
+### 環境變數隔離
+每個測試前後必須儲存/還原 `process.env`
+</testing>
+
+<architecture>
+## 專案架構
+
+```
+js-gcp-logger/
+├── src/
+│   ├── index.ts          # 主入口，所有匯出
+│   └── index.test.ts     # 測試
+├── dist/                  # 編譯輸出（gitignore）
+├── package.json
+├── tsconfig.json
+└── vitest.config.ts
+```
+
+### 匯出結構
+```typescript
+export type Logger = ILogLayer
+export interface LoggerOptions { ... }
+export function createLogger(options?: LoggerOptions): Logger
+export { LogLayer }
+```
+
+### 環境變數
+- `NODE_ENV`: 環境偵測（`production` | `development`）
+- `K_SERVICE`, `K_REVISION`, `K_CONFIGURATION`: GCP Cloud Run 偵測
+</architecture>
+
+<known_issues>
+## 已知問題與陷阱
+
+1. **pino 類型不相容**：`createGcpLoggingPinoConfig()` 需用 `as any` 轉換
+   - 這是上游類型問題，保持現狀
+
+2. **ESM 模組**：專案使用 `"type": "module"`，相對路徑 import 需注意
+
+3. **測試隔離**：環境變數測試必須在 beforeEach/afterEach 中隔離
+</known_issues>
+
+<dependencies>
+## 依賴
+
+**生產**：loglayer, pino, @google-cloud/pino-logging-gcp-config, @loglayer/transport-pino, @loglayer/transport-simple-pretty-terminal, serialize-error
+
+**開發**：typescript ^5.7, vitest ^4.0, @types/node ^22
+
+**發佈**：GitHub Packages (@taiwanta), ESM, Node.js >= 18
+</dependencies>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,7 @@
 零配置 GCP 日誌整合，使用 `loglayer` + `pino`。
 - 生產環境：pino + @google-cloud/pino-logging-gcp-config
 - 開發環境：@loglayer/transport-simple-pretty-terminal
-
-結構簡單：`src/index.ts`（入口）+ `src/index.test.ts`（測試）
+- Hono middleware：自動關聯 GCP trace context
 </project_overview>
 
 <commands>
@@ -120,9 +119,22 @@ it('當 NODE_ENV 為 production 時應使用生產環境傳輸', () => {})
 ```
 js-gcp-logger/
 ├── src/
-│   ├── index.ts          # 主入口，所有匯出
-│   └── index.test.ts     # 測試
-├── dist/                  # 編譯輸出（gitignore）
+│   ├── index.ts              # 主入口，所有匯出
+│   ├── index.test.ts         # 主入口測試
+│   ├── context.ts            # AsyncLocalStorage 管理、trace 解析
+│   ├── context.test.ts       # context 測試
+│   └── middleware/
+│       └── hono/
+│           ├── index.ts              # Hono middleware
+│           ├── index.test.ts         # middleware 單元測試
+│           └── integration.test.ts   # middleware 整合測試
+├── examples/
+│   ├── basic.js              # 基本使用範例
+│   ├── hono-server.ts        # Hono 測試伺服器
+│   ├── deploy-to-cloudrun.sh # Cloud Run 部署腳本
+│   └── test-middleware.sh    # 本地驗證腳本
+├── Dockerfile                # Cloud Run 部署用
+├── dist/                     # 編譯輸出（gitignore）
 ├── package.json
 ├── tsconfig.json
 └── vitest.config.ts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:22-slim
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+RUN npm install @hono/node-server tsx
+
+ENV NODE_ENV=production
+ENV PORT=8080
+
+EXPOSE 8080
+
+CMD ["npx", "tsx", "examples/hono-server.ts"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,6 @@ RUN npm ci
 COPY . .
 RUN npm run build
 
-RUN npm install @hono/node-server tsx
-
 ENV NODE_ENV=production
 ENV PORT=8080
 

--- a/examples/deploy-to-cloudrun.sh
+++ b/examples/deploy-to-cloudrun.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -e
+
+PROJECT_ID="${GOOGLE_CLOUD_PROJECT:-}"
+REGION="${REGION:-asia-east1}"
+SERVICE_NAME="gcp-logger-test"
+
+if [ -z "$PROJECT_ID" ]; then
+    echo "❌ 請設定 GOOGLE_CLOUD_PROJECT 環境變數"
+    echo ""
+    echo "使用方式："
+    echo "  export GOOGLE_CLOUD_PROJECT=your-project-id"
+    echo "  ./examples/deploy-to-cloudrun.sh"
+    exit 1
+fi
+
+echo "============================================================"
+echo "部署 GCP Logger 測試應用到 Cloud Run"
+echo "============================================================"
+echo "專案: $PROJECT_ID"
+echo "區域: $REGION"
+echo "服務: $SERVICE_NAME"
+echo "============================================================"
+echo ""
+
+cd "$(dirname "$0")/.."
+
+echo "1. 部署到 Cloud Run..."
+gcloud run deploy "$SERVICE_NAME" \
+    --project="$PROJECT_ID" \
+    --region="$REGION" \
+    --source=. \
+    --allow-unauthenticated \
+    --set-env-vars="GOOGLE_CLOUD_PROJECT=$PROJECT_ID" \
+    --clear-base-image
+
+echo ""
+echo "2. 取得服務 URL..."
+SERVICE_URL=$(gcloud run services describe "$SERVICE_NAME" \
+    --project="$PROJECT_ID" \
+    --region="$REGION" \
+    --format="value(status.url)")
+
+echo ""
+echo "============================================================"
+echo "✅ 部署完成！"
+echo "============================================================"
+echo ""
+echo "服務 URL: $SERVICE_URL"
+echo ""
+echo "測試指令："
+echo "  curl $SERVICE_URL/"
+echo "  curl $SERVICE_URL/debug"
+echo "  curl $SERVICE_URL/log-test"
+echo ""
+echo "查看日誌："
+echo "  https://console.cloud.google.com/logs/query?project=$PROJECT_ID"
+echo ""

--- a/examples/hono-server.ts
+++ b/examples/hono-server.ts
@@ -1,0 +1,147 @@
+/**
+ * Hono 測試伺服器 - 用於驗證 GCP Logger Middleware
+ *
+ * 執行方式：
+ *   npx tsx examples/hono-server.ts
+ *
+ * 測試指令：
+ *   curl http://localhost:3000/
+ *   curl http://localhost:3000/debug
+ *   curl -H "X-Cloud-Trace-Context: 105445aa7843bc8bf206b12000100000/1;o=1" http://localhost:3000/debug
+ */
+
+import { serve } from '@hono/node-server'
+import { Hono } from 'hono'
+import { createLogger, getRequestLogger, getTraceContext } from '../dist/index.js'
+import { gcpLoggerMiddleware } from '../dist/middleware/hono/index.js'
+
+const app = new Hono()
+const logger = createLogger()
+
+console.log('='.repeat(60))
+console.log('GCP Logger Middleware 測試伺服器')
+console.log('='.repeat(60))
+console.log('環境變數：')
+console.log(`  NODE_ENV: ${process.env.NODE_ENV ?? '(未設定)'}`)
+console.log(`  K_SERVICE: ${process.env.K_SERVICE ?? '(未設定 - 非 Cloud Run)'}`)
+console.log(`  K_REVISION: ${process.env.K_REVISION ?? '(未設定)'}`)
+console.log(`  GOOGLE_CLOUD_PROJECT: ${process.env.GOOGLE_CLOUD_PROJECT ?? '(未設定)'}`)
+console.log('='.repeat(60))
+
+app.use(
+  '*',
+  gcpLoggerMiddleware({
+    logger,
+    projectId: process.env.GOOGLE_CLOUD_PROJECT ?? 'test-project',
+  })
+)
+
+app.get('/', (c) => {
+  const log = getRequestLogger()
+  log?.info('收到首頁請求')
+
+  return c.json({
+    message: 'GCP Logger Middleware 測試伺服器',
+    endpoints: {
+      '/': '首頁',
+      '/debug': '顯示 trace context 詳細資訊',
+      '/log-test': '觸發多個日誌輸出',
+      '/error-test': '觸發錯誤日誌',
+      '/async-test': '測試非同步操作中的 context 傳播',
+    },
+  })
+})
+
+app.get('/debug', (c) => {
+  const log = getRequestLogger()
+  const trace = getTraceContext()
+
+  log?.info('Debug 端點被呼叫')
+
+  return c.json({
+    traceContext: trace,
+    honoContext: {
+      requestId: c.get('requestId'),
+      traceId: c.get('traceId'),
+    },
+    headers: {
+      'X-Cloud-Trace-Context': c.req.header('X-Cloud-Trace-Context') ?? '(未提供)',
+      'X-Request-ID': c.req.header('X-Request-ID') ?? '(未提供)',
+    },
+    responseHeaders: {
+      'X-Request-ID': c.res.headers.get('X-Request-ID'),
+    },
+  })
+})
+
+app.get('/log-test', (c) => {
+  const log = getRequestLogger()
+
+  log?.trace('這是 trace 級別日誌')
+  log?.debug('這是 debug 級別日誌')
+  log?.info('這是 info 級別日誌')
+  log?.warn('這是 warn 級別日誌')
+
+  log?.info('帶有 metadata 的日誌', {
+    userId: 'user-123',
+    action: 'test',
+    timestamp: new Date().toISOString(),
+  })
+
+  return c.json({
+    message: '已輸出多個日誌，請檢查終端機輸出',
+    tip: '在 Cloud Run 上，這些日誌會出現在 Cloud Logging 並關聯到同一個 trace',
+  })
+})
+
+app.get('/error-test', (c) => {
+  const log = getRequestLogger()
+
+  try {
+    throw new Error('這是測試錯誤')
+  } catch (error) {
+    log?.withError(error as Error).error('捕獲到錯誤')
+  }
+
+  return c.json({ message: '已輸出錯誤日誌' })
+})
+
+app.get('/async-test', async (c) => {
+  const log = getRequestLogger()
+  const trace = getTraceContext()
+
+  log?.info('開始非同步操作')
+
+  await new Promise((resolve) => setTimeout(resolve, 100))
+
+  const traceAfterAwait = getTraceContext()
+  const logAfterAwait = getRequestLogger()
+
+  logAfterAwait?.info('非同步操作完成')
+
+  const contextPreserved =
+    trace?.traceId === traceAfterAwait?.traceId &&
+    trace?.requestId === traceAfterAwait?.requestId
+
+  return c.json({
+    contextPreserved,
+    before: { traceId: trace?.traceId, requestId: trace?.requestId },
+    after: { traceId: traceAfterAwait?.traceId, requestId: traceAfterAwait?.requestId },
+    message: contextPreserved
+      ? '✅ AsyncLocalStorage 正確傳播 context'
+      : '❌ Context 在非同步操作後遺失',
+  })
+})
+
+const port = Number(process.env.PORT) || 3000
+
+serve({ fetch: app.fetch, port }, (info) => {
+  console.log(`\n🚀 伺服器啟動於 http://localhost:${info.port}`)
+  console.log('\n測試指令：')
+  console.log(`  curl http://localhost:${info.port}/`)
+  console.log(`  curl http://localhost:${info.port}/debug`)
+  console.log(
+    `  curl -H "X-Cloud-Trace-Context: 105445aa7843bc8bf206b12000100000/1;o=1" http://localhost:${info.port}/debug`
+  )
+  console.log('')
+})

--- a/examples/test-middleware.sh
+++ b/examples/test-middleware.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+# 本地驗證 GCP Logger Middleware 行為的腳本
+
+set -e
+
+PORT=3000
+BASE_URL="http://localhost:$PORT"
+
+echo "============================================================"
+echo "GCP Logger Middleware 本地驗證測試"
+echo "============================================================"
+echo ""
+
+check_server() {
+    curl -s --max-time 1 "$BASE_URL/" > /dev/null 2>&1
+}
+
+if ! check_server; then
+    echo "❌ 伺服器未在 $BASE_URL 運行"
+    echo ""
+    echo "請先啟動伺服器："
+    echo "  npx tsx examples/hono-server.ts"
+    exit 1
+fi
+
+echo "✅ 伺服器正在運行"
+echo ""
+
+run_test() {
+    local name="$1"
+    local expected="$2"
+    local actual="$3"
+    
+    if echo "$actual" | grep -q "$expected"; then
+        echo "  ✅ $name"
+        return 0
+    else
+        echo "  ❌ $name"
+        echo "     期望包含: $expected"
+        echo "     實際結果: $actual"
+        return 1
+    fi
+}
+
+FAILED=0
+
+echo "測試 1: 無 X-Cloud-Trace-Context header（應自動產生）"
+echo "-------------------------------------------------------------"
+RESPONSE=$(curl -s "$BASE_URL/debug")
+echo "回應: $RESPONSE"
+echo ""
+
+if echo "$RESPONSE" | grep -q '"traceId"'; then
+    echo "  ✅ traceId 已產生"
+else
+    echo "  ❌ traceId 未產生"
+    FAILED=1
+fi
+
+if echo "$RESPONSE" | grep -q '"requestId"'; then
+    echo "  ✅ requestId 已產生"
+else
+    echo "  ❌ requestId 未產生"
+    FAILED=1
+fi
+
+if echo "$RESPONSE" | grep -q '"X-Cloud-Trace-Context":"(未提供)"'; then
+    echo "  ✅ 正確識別無 trace header"
+else
+    echo "  ❌ trace header 狀態錯誤"
+    FAILED=1
+fi
+
+echo ""
+echo "測試 2: 帶 X-Cloud-Trace-Context header（應解析）"
+echo "-------------------------------------------------------------"
+TRACE_HEADER="105445aa7843bc8bf206b12000100000/12345;o=1"
+RESPONSE=$(curl -s -H "X-Cloud-Trace-Context: $TRACE_HEADER" "$BASE_URL/debug")
+echo "回應: $RESPONSE"
+echo ""
+
+if echo "$RESPONSE" | grep -q '"traceId":"105445aa7843bc8bf206b12000100000"'; then
+    echo "  ✅ traceId 正確解析"
+else
+    echo "  ❌ traceId 解析錯誤"
+    FAILED=1
+fi
+
+if echo "$RESPONSE" | grep -q '"spanId":"12345"'; then
+    echo "  ✅ spanId 正確解析"
+else
+    echo "  ❌ spanId 解析錯誤"
+    FAILED=1
+fi
+
+if echo "$RESPONSE" | grep -q '"traceSampled":true'; then
+    echo "  ✅ traceSampled 正確解析"
+else
+    echo "  ❌ traceSampled 解析錯誤"
+    FAILED=1
+fi
+
+echo ""
+echo "測試 3: AsyncLocalStorage 傳播"
+echo "-------------------------------------------------------------"
+RESPONSE=$(curl -s "$BASE_URL/async-test")
+echo "回應: $RESPONSE"
+echo ""
+
+if echo "$RESPONSE" | grep -q '"contextPreserved":true'; then
+    echo "  ✅ Context 在非同步操作後正確保留"
+else
+    echo "  ❌ Context 在非同步操作後遺失"
+    FAILED=1
+fi
+
+echo ""
+echo "測試 4: X-Request-ID 回應 header"
+echo "-------------------------------------------------------------"
+RESPONSE_HEADERS=$(curl -sI "$BASE_URL/debug" 2>&1)
+echo "回應 headers:"
+echo "$RESPONSE_HEADERS" | grep -i "x-request-id" || echo "(無 X-Request-ID)"
+echo ""
+
+if echo "$RESPONSE_HEADERS" | grep -qi "x-request-id"; then
+    echo "  ✅ X-Request-ID 已設定在回應 header"
+else
+    echo "  ❌ X-Request-ID 未設定在回應 header"
+    FAILED=1
+fi
+
+echo ""
+echo "============================================================"
+if [ $FAILED -eq 0 ]; then
+    echo "✅ 所有測試通過！"
+    echo ""
+    echo "Middleware 行為驗證成功："
+    echo "  - X-Cloud-Trace-Context header 正確解析"
+    echo "  - 無 header 時自動產生 trace ID"
+    echo "  - AsyncLocalStorage 正確傳播 context"
+    echo "  - X-Request-ID 正確設定"
+    echo ""
+    echo "下一步：部署到 Cloud Run 驗證 Cloud Logging 整合"
+else
+    echo "❌ 部分測試失敗"
+    exit 1
+fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,12 +18,23 @@
         "serialize-error": "^12.0.0"
       },
       "devDependencies": {
+        "@hono/node-server": "^1.19.7",
         "@types/node": "^22.0.0",
+        "hono": "^4.11.3",
+        "tsx": "^4.21.0",
         "typescript": "^5.7.0",
         "vitest": "^4.0.0"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "hono": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "hono": {
+          "optional": true
+        }
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -607,6 +618,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.7",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.7.tgz",
+      "integrity": "sha512-vUcD0uauS7EU2caukW8z5lJKtoGMokxNbJtBiwHgpqxEXokaHCBkQUmCHhjFB1VUTWdqj25QoMkMKzgjq+uhrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -1894,6 +1918,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
+      "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/google-auth-library": {
       "version": "9.15.1",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
@@ -2005,6 +2042,17 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.3.tgz",
+      "integrity": "sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/html-entities": {
@@ -2497,6 +2545,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/retry-request": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-7.0.2.tgz",
@@ -2807,6 +2865,27 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-fest": {
       "version": "4.41.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./middleware/hono": {
+      "import": "./dist/middleware/hono/index.js",
+      "types": "./dist/middleware/hono/index.d.ts"
     }
   },
   "files": [
@@ -41,9 +45,20 @@
     "serialize-error": "^12.0.0"
   },
   "devDependencies": {
+    "@hono/node-server": "^1.19.7",
     "@types/node": "^22.0.0",
+    "hono": "^4.11.3",
+    "tsx": "^4.21.0",
     "typescript": "^5.7.0",
     "vitest": "^4.0.0"
+  },
+  "peerDependencies": {
+    "hono": "^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "hono": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=18"

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import {
+  parseCloudTraceHeader,
+  formatTraceField,
+  generateRequestId,
+  generateTraceId,
+  getRequestLogger,
+  getTraceContext,
+  runWithRequestContext,
+  asyncLocalStorage,
+} from './context'
+import type { RequestStore, TraceContext } from './context'
+import type { ILogLayer } from 'loglayer'
+
+describe('parseCloudTraceHeader', () => {
+  it('應該正確解析完整的 X-Cloud-Trace-Context header', () => {
+    const header = '105445aa7843bc8bf206b12000100000/1;o=1'
+    const result = parseCloudTraceHeader(header)
+
+    expect(result).toEqual({
+      traceId: '105445aa7843bc8bf206b12000100000',
+      spanId: '1',
+      traceSampled: true,
+    })
+  })
+
+  it('當 o=0 時應回傳 traceSampled 為 false', () => {
+    const header = 'abcdef12345678901234567890abcdef/123456;o=0'
+    const result = parseCloudTraceHeader(header)
+
+    expect(result).toEqual({
+      traceId: 'abcdef12345678901234567890abcdef',
+      spanId: '123456',
+      traceSampled: false,
+    })
+  })
+
+  it('當省略 options 時應預設 traceSampled 為 false', () => {
+    const header = '105445aa7843bc8bf206b12000100000/1'
+    const result = parseCloudTraceHeader(header)
+
+    expect(result).toEqual({
+      traceId: '105445aa7843bc8bf206b12000100000',
+      spanId: '1',
+      traceSampled: false,
+    })
+  })
+
+  it('應該將 traceId 轉為小寫', () => {
+    const header = 'ABCDEF12345678901234567890ABCDEF/1;o=1'
+    const result = parseCloudTraceHeader(header)
+
+    expect(result?.traceId).toBe('abcdef12345678901234567890abcdef')
+  })
+
+  it('當 header 為 null 時應回傳 null', () => {
+    expect(parseCloudTraceHeader(null)).toBeNull()
+  })
+
+  it('當 header 為 undefined 時應回傳 null', () => {
+    expect(parseCloudTraceHeader(undefined)).toBeNull()
+  })
+
+  it('當 header 為空字串時應回傳 null', () => {
+    expect(parseCloudTraceHeader('')).toBeNull()
+  })
+
+  it('當格式無效時應回傳 null', () => {
+    expect(parseCloudTraceHeader('invalid-format')).toBeNull()
+    expect(parseCloudTraceHeader('too-short/1')).toBeNull()
+    expect(parseCloudTraceHeader('not-hex-chars-here-32-characters')).toBeNull()
+  })
+
+  it('當只有 traceId 時應透過寬鬆解析回傳預設值', () => {
+    const result = parseCloudTraceHeader('105445aa7843bc8bf206b12000100000')
+    expect(result).toEqual({
+      traceId: '105445aa7843bc8bf206b12000100000',
+      spanId: '0',
+      traceSampled: false,
+    })
+  })
+
+  it('應該支援寬鬆解析（只有 traceId）', () => {
+    const header = '105445aa7843bc8bf206b12000100000/abc'
+    const result = parseCloudTraceHeader(header)
+
+    expect(result).toEqual({
+      traceId: '105445aa7843bc8bf206b12000100000',
+      spanId: '0',
+      traceSampled: false,
+    })
+  })
+
+  it('應該處理大的 spanId 數值', () => {
+    const header = '105445aa7843bc8bf206b12000100000/18446744073709551615;o=1'
+    const result = parseCloudTraceHeader(header)
+
+    expect(result?.spanId).toBe('18446744073709551615')
+  })
+})
+
+describe('formatTraceField', () => {
+  it('應該產生正確的 GCP trace 欄位格式', () => {
+    const result = formatTraceField('my-project', 'abc123def456')
+    expect(result).toBe('projects/my-project/traces/abc123def456')
+  })
+
+  it('應該處理包含特殊字元的 projectId', () => {
+    const result = formatTraceField('my-project-123', 'trace-id')
+    expect(result).toBe('projects/my-project-123/traces/trace-id')
+  })
+})
+
+describe('generateRequestId', () => {
+  it('應該產生 UUID 格式的 requestId', () => {
+    const requestId = generateRequestId()
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    expect(requestId).toMatch(uuidRegex)
+  })
+
+  it('每次呼叫應產生不同的 requestId', () => {
+    const id1 = generateRequestId()
+    const id2 = generateRequestId()
+    expect(id1).not.toBe(id2)
+  })
+})
+
+describe('generateTraceId', () => {
+  it('應該產生 32 字元的十六進制 traceId', () => {
+    const traceId = generateTraceId()
+    expect(traceId).toMatch(/^[0-9a-f]{32}$/)
+  })
+
+  it('每次呼叫應產生不同的 traceId', () => {
+    const id1 = generateTraceId()
+    const id2 = generateTraceId()
+    expect(id1).not.toBe(id2)
+  })
+
+  it('不應包含連字號', () => {
+    const traceId = generateTraceId()
+    expect(traceId).not.toContain('-')
+  })
+})
+
+describe('AsyncLocalStorage 整合', () => {
+  const mockLogger = {
+    info: () => {},
+    withContext: () => mockLogger,
+  } as unknown as ILogLayer
+
+  const mockStore: RequestStore = {
+    trace: {
+      traceId: 'test-trace-id',
+      spanId: '123',
+      requestId: 'test-request-id',
+      traceSampled: true,
+    },
+    logger: mockLogger,
+  }
+
+  afterEach(() => {
+    asyncLocalStorage.disable()
+  })
+
+  describe('getRequestLogger', () => {
+    it('在請求範圍內應回傳 logger', () => {
+      runWithRequestContext(mockStore, () => {
+        const logger = getRequestLogger()
+        expect(logger).toBe(mockLogger)
+      })
+    })
+
+    it('在請求範圍外應回傳 undefined', () => {
+      const logger = getRequestLogger()
+      expect(logger).toBeUndefined()
+    })
+  })
+
+  describe('getTraceContext', () => {
+    it('在請求範圍內應回傳 trace context', () => {
+      runWithRequestContext(mockStore, () => {
+        const trace = getTraceContext()
+        expect(trace).toEqual(mockStore.trace)
+      })
+    })
+
+    it('在請求範圍外應回傳 undefined', () => {
+      const trace = getTraceContext()
+      expect(trace).toBeUndefined()
+    })
+  })
+
+  describe('runWithRequestContext', () => {
+    it('應該在 context 中執行同步函式並回傳結果', () => {
+      const result = runWithRequestContext(mockStore, () => {
+        return 'sync-result'
+      })
+      expect(result).toBe('sync-result')
+    })
+
+    it('應該在 context 中執行非同步函式', async () => {
+      const result = await runWithRequestContext(mockStore, async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10))
+        return getTraceContext()?.traceId
+      })
+      expect(result).toBe('test-trace-id')
+    })
+
+    it('巢狀的 context 應該正確隔離', () => {
+      const outerStore: RequestStore = {
+        ...mockStore,
+        trace: { ...mockStore.trace, traceId: 'outer-trace' },
+      }
+      const innerStore: RequestStore = {
+        ...mockStore,
+        trace: { ...mockStore.trace, traceId: 'inner-trace' },
+      }
+
+      runWithRequestContext(outerStore, () => {
+        expect(getTraceContext()?.traceId).toBe('outer-trace')
+
+        runWithRequestContext(innerStore, () => {
+          expect(getTraceContext()?.traceId).toBe('inner-trace')
+        })
+
+        expect(getTraceContext()?.traceId).toBe('outer-trace')
+      })
+    })
+
+    it('應該在非同步操作中保持 context', async () => {
+      const results: string[] = []
+
+      await runWithRequestContext(mockStore, async () => {
+        results.push(getTraceContext()?.traceId ?? 'none')
+
+        await Promise.all([
+          (async () => {
+            await new Promise((resolve) => setTimeout(resolve, 5))
+            results.push(getTraceContext()?.traceId ?? 'none')
+          })(),
+          (async () => {
+            await new Promise((resolve) => setTimeout(resolve, 10))
+            results.push(getTraceContext()?.traceId ?? 'none')
+          })(),
+        ])
+
+        results.push(getTraceContext()?.traceId ?? 'none')
+      })
+
+      expect(results).toEqual([
+        'test-trace-id',
+        'test-trace-id',
+        'test-trace-id',
+        'test-trace-id',
+      ])
+    })
+  })
+})

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,0 +1,154 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+import type { ILogLayer } from 'loglayer'
+
+/**
+ * 請求追蹤上下文資料
+ */
+export interface TraceContext {
+  /** GCP Trace ID（32 字元十六進制） */
+  traceId: string
+  /** Span ID */
+  spanId: string
+  /** 請求 ID（UUID） */
+  requestId: string
+  /** 是否啟用追蹤取樣 */
+  traceSampled: boolean
+}
+
+/**
+ * AsyncLocalStorage 儲存的資料結構
+ */
+export interface RequestStore {
+  /** 追蹤上下文 */
+  trace: TraceContext
+  /** 帶有上下文的 logger 實例 */
+  logger: ILogLayer
+}
+
+/**
+ * 全域 AsyncLocalStorage 實例
+ * 用於在非同步操作中傳遞請求上下文
+ */
+export const asyncLocalStorage = new AsyncLocalStorage<RequestStore>()
+
+/**
+ * 解析 GCP X-Cloud-Trace-Context header
+ * 
+ * 格式：TRACE_ID/SPAN_ID;o=OPTIONS
+ * - TRACE_ID: 32 字元十六進制值（128 位元）
+ * - SPAN_ID: 十進制數字（64 位元）
+ * - OPTIONS: 0（未取樣）或 1（已取樣）
+ * 
+ * @param header - X-Cloud-Trace-Context header 值
+ * @returns 解析後的 trace context，若 header 為空則回傳 null
+ * 
+ * @example
+ * ```typescript
+ * const ctx = parseCloudTraceHeader('105445aa7843bc8bf206b12000100000/1;o=1')
+ * // { traceId: '105445aa7843bc8bf206b12000100000', spanId: '1', traceSampled: true }
+ * ```
+ * 
+ * @see https://cloud.google.com/trace/docs/trace-context
+ */
+export function parseCloudTraceHeader(header: string | null | undefined): Omit<TraceContext, 'requestId'> | null {
+  if (!header) {
+    return null
+  }
+
+  // 格式：TRACE_ID/SPAN_ID;o=OPTIONS
+  const regex = /^([a-fA-F0-9]{32})\/(\d+)(?:;o=([01]))?$/
+  const match = header.match(regex)
+
+  if (!match) {
+    // 嘗試寬鬆解析（只取 trace ID）
+    const looseMatch = header.match(/^([a-fA-F0-9]{32})/)
+    if (looseMatch) {
+      return {
+        traceId: looseMatch[1].toLowerCase(),
+        spanId: '0',
+        traceSampled: false,
+      }
+    }
+    return null
+  }
+
+  return {
+    traceId: match[1].toLowerCase(),
+    spanId: match[2],
+    traceSampled: match[3] === '1',
+  }
+}
+
+/**
+ * 產生 GCP Cloud Logging 所需的 trace 欄位值
+ * 
+ * @param projectId - GCP 專案 ID
+ * @param traceId - Trace ID
+ * @returns 格式化的 trace 路徑
+ * 
+ * @example
+ * ```typescript
+ * formatTraceField('my-project', 'abc123...')
+ * // 'projects/my-project/traces/abc123...'
+ * ```
+ * 
+ * @see https://cloud.google.com/logging/docs/view/correlate-logs
+ */
+export function formatTraceField(projectId: string, traceId: string): string {
+  return `projects/${projectId}/traces/${traceId}`
+}
+
+/**
+ * 產生新的請求 ID（UUID v4 格式）
+ */
+export function generateRequestId(): string {
+  return crypto.randomUUID()
+}
+
+/**
+ * 產生新的 Trace ID（32 字元十六進制）
+ */
+export function generateTraceId(): string {
+  return crypto.randomUUID().replace(/-/g, '')
+}
+
+/**
+ * 取得當前請求的 logger 實例
+ * 
+ * 此 logger 已自動包含 trace context（traceId, spanId, requestId）
+ * 必須在 middleware 設定的請求範圍內呼叫
+ * 
+ * @returns 帶有請求上下文的 logger，若不在請求範圍內則回傳 undefined
+ * 
+ * @example
+ * ```typescript
+ * app.get('/', (c) => {
+ *   const log = getRequestLogger()
+ *   log?.info('處理請求')  // 自動包含 traceId, spanId, requestId
+ *   return c.text('OK')
+ * })
+ * ```
+ */
+export function getRequestLogger(): ILogLayer | undefined {
+  return asyncLocalStorage.getStore()?.logger
+}
+
+/**
+ * 取得當前請求的追蹤上下文
+ * 
+ * @returns 追蹤上下文，若不在請求範圍內則回傳 undefined
+ */
+export function getTraceContext(): TraceContext | undefined {
+  return asyncLocalStorage.getStore()?.trace
+}
+
+/**
+ * 在指定的請求上下文中執行函式
+ * 
+ * @param store - 請求儲存資料
+ * @param fn - 要執行的函式
+ * @returns 函式執行結果
+ */
+export function runWithRequestContext<T>(store: RequestStore, fn: () => T): T {
+  return asyncLocalStorage.run(store, fn)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,17 +31,14 @@ export interface LoggerOptions {
  * @returns 若為生產環境回傳 'production'，否則回傳 'development'
  */
 function detectEnvironment(): string {
-  // 優先檢查 NODE_ENV
   if (process.env.NODE_ENV) {
     return process.env.NODE_ENV
   }
   
-  // 檢查 GCP Cloud Run 環境變數
   if (process.env.K_SERVICE || process.env.K_REVISION || process.env.K_CONFIGURATION) {
     return 'production'
   }
   
-  // 預設為開發環境
   return 'development'
 }
 
@@ -102,5 +99,11 @@ export function createLogger(options?: LoggerOptions): Logger {
   })
 }
 
-// 為方便使用，重新匯出 LogLayer
 export { LogLayer }
+
+export {
+  getRequestLogger,
+  getTraceContext,
+  asyncLocalStorage,
+} from './context'
+export type { TraceContext, RequestStore } from './context'

--- a/src/middleware/hono/index.test.ts
+++ b/src/middleware/hono/index.test.ts
@@ -1,0 +1,412 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { Hono } from 'hono'
+import { gcpLoggerMiddleware } from './index'
+import { getRequestLogger, getTraceContext, asyncLocalStorage } from '../../context'
+import type { ILogLayer } from 'loglayer'
+
+function createMockLogger(): ILogLayer & { contextData: Record<string, unknown> } {
+  const contextData: Record<string, unknown> = {}
+
+  const mockLogger = {
+    contextData,
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    trace: vi.fn(),
+    fatal: vi.fn(),
+    withContext: vi.fn((ctx: Record<string, unknown>) => {
+      Object.assign(contextData, ctx)
+      return mockLogger
+    }),
+    withError: vi.fn(() => mockLogger),
+    withMetadata: vi.fn(() => mockLogger),
+    child: vi.fn(() => mockLogger),
+  } as unknown as ILogLayer & { contextData: Record<string, unknown> }
+
+  return mockLogger
+}
+
+describe('gcpLoggerMiddleware', () => {
+  let originalEnv: NodeJS.ProcessEnv
+
+  beforeEach(() => {
+    originalEnv = { ...process.env }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    asyncLocalStorage.disable()
+    vi.restoreAllMocks()
+  })
+
+  describe('Trace Header 解析', () => {
+    it('應該正確解析 X-Cloud-Trace-Context header', async () => {
+      const mockLogger = createMockLogger()
+      const app = new Hono()
+
+      app.use('*', gcpLoggerMiddleware({ logger: mockLogger, projectId: 'test-project' }))
+      app.get('/', (c) => {
+        const trace = getTraceContext()
+        return c.json({
+          traceId: trace?.traceId,
+          spanId: trace?.spanId,
+          traceSampled: trace?.traceSampled,
+        })
+      })
+
+      const res = await app.request('/', {
+        headers: {
+          'X-Cloud-Trace-Context': '105445aa7843bc8bf206b12000100000/12345;o=1',
+        },
+      })
+
+      const body = await res.json()
+      expect(body.traceId).toBe('105445aa7843bc8bf206b12000100000')
+      expect(body.spanId).toBe('12345')
+      expect(body.traceSampled).toBe(true)
+    })
+
+    it('當沒有 trace header 時應產生新的 traceId', async () => {
+      const mockLogger = createMockLogger()
+      const app = new Hono()
+
+      app.use('*', gcpLoggerMiddleware({ logger: mockLogger, projectId: 'test-project' }))
+      app.get('/', (c) => {
+        const trace = getTraceContext()
+        return c.json({ traceId: trace?.traceId })
+      })
+
+      const res = await app.request('/')
+      const body = await res.json()
+
+      expect(body.traceId).toMatch(/^[0-9a-f]{32}$/)
+    })
+
+    it('當 trace header 格式無效時應產生新的 traceId', async () => {
+      const mockLogger = createMockLogger()
+      const app = new Hono()
+
+      app.use('*', gcpLoggerMiddleware({ logger: mockLogger, projectId: 'test-project' }))
+      app.get('/', (c) => {
+        const trace = getTraceContext()
+        return c.json({ traceId: trace?.traceId })
+      })
+
+      const res = await app.request('/', {
+        headers: {
+          'X-Cloud-Trace-Context': 'invalid-header',
+        },
+      })
+
+      const body = await res.json()
+      expect(body.traceId).toMatch(/^[0-9a-f]{32}$/)
+    })
+  })
+
+  describe('Request ID 處理', () => {
+    it('應該使用現有的 X-Request-ID header', async () => {
+      const mockLogger = createMockLogger()
+      const app = new Hono()
+
+      app.use('*', gcpLoggerMiddleware({ logger: mockLogger, projectId: 'test-project' }))
+      app.get('/', (c) => {
+        const trace = getTraceContext()
+        return c.json({ requestId: trace?.requestId })
+      })
+
+      const res = await app.request('/', {
+        headers: {
+          'X-Request-ID': 'existing-request-id-123',
+        },
+      })
+
+      const body = await res.json()
+      expect(body.requestId).toBe('existing-request-id-123')
+    })
+
+    it('當沒有 X-Request-ID 時應產生新的 requestId', async () => {
+      const mockLogger = createMockLogger()
+      const app = new Hono()
+
+      app.use('*', gcpLoggerMiddleware({ logger: mockLogger, projectId: 'test-project' }))
+      app.get('/', (c) => {
+        const trace = getTraceContext()
+        return c.json({ requestId: trace?.requestId })
+      })
+
+      const res = await app.request('/')
+      const body = await res.json()
+
+      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      expect(body.requestId).toMatch(uuidRegex)
+    })
+
+    it('應該在回應 header 中設定 X-Request-ID', async () => {
+      const mockLogger = createMockLogger()
+      const app = new Hono()
+
+      app.use('*', gcpLoggerMiddleware({ logger: mockLogger, projectId: 'test-project' }))
+      app.get('/', (c) => c.text('OK'))
+
+      const res = await app.request('/')
+
+      expect(res.headers.get('X-Request-ID')).toBeTruthy()
+    })
+  })
+
+  describe('Logger Context 設定', () => {
+    it('應該設定正確的 GCP logging 欄位', async () => {
+      const mockLogger = createMockLogger()
+      const app = new Hono()
+
+      app.use('*', gcpLoggerMiddleware({ logger: mockLogger, projectId: 'my-gcp-project' }))
+      app.get('/', (c) => c.text('OK'))
+
+      await app.request('/', {
+        headers: {
+          'X-Cloud-Trace-Context': 'abcdef12345678901234567890abcdef/999;o=1',
+        },
+      })
+
+      expect(mockLogger.withContext).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'logging.googleapis.com/trace': 'projects/my-gcp-project/traces/abcdef12345678901234567890abcdef',
+          'logging.googleapis.com/spanId': '999',
+          'logging.googleapis.com/trace_sampled': true,
+        })
+      )
+    })
+
+    it('應該從環境變數取得 projectId', async () => {
+      process.env.GOOGLE_CLOUD_PROJECT = 'env-project-id'
+
+      const mockLogger = createMockLogger()
+      const app = new Hono()
+
+      app.use('*', gcpLoggerMiddleware({ logger: mockLogger }))
+      app.get('/', (c) => c.text('OK'))
+
+      await app.request('/', {
+        headers: {
+          'X-Cloud-Trace-Context': 'abcdef12345678901234567890abcdef/1;o=0',
+        },
+      })
+
+      expect(mockLogger.withContext).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'logging.googleapis.com/trace': 'projects/env-project-id/traces/abcdef12345678901234567890abcdef',
+        })
+      )
+    })
+
+    it('應該優先使用 options.projectId', async () => {
+      process.env.GOOGLE_CLOUD_PROJECT = 'env-project-id'
+
+      const mockLogger = createMockLogger()
+      const app = new Hono()
+
+      app.use('*', gcpLoggerMiddleware({ logger: mockLogger, projectId: 'options-project-id' }))
+      app.get('/', (c) => c.text('OK'))
+
+      await app.request('/', {
+        headers: {
+          'X-Cloud-Trace-Context': 'abcdef12345678901234567890abcdef/1;o=0',
+        },
+      })
+
+      expect(mockLogger.withContext).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'logging.googleapis.com/trace': 'projects/options-project-id/traces/abcdef12345678901234567890abcdef',
+        })
+      )
+    })
+  })
+
+  describe('getRequestLogger 整合', () => {
+    it('在 handler 中應能取得帶有 context 的 logger', async () => {
+      const mockLogger = createMockLogger()
+      const app = new Hono()
+
+      app.use('*', gcpLoggerMiddleware({ logger: mockLogger, projectId: 'test-project' }))
+      app.get('/', (c) => {
+        const log = getRequestLogger()
+        expect(log).toBeDefined()
+        return c.text('OK')
+      })
+
+      await app.request('/')
+    })
+
+    it('logger 應包含 trace context', async () => {
+      const mockLogger = createMockLogger()
+      const app = new Hono()
+
+      app.use('*', gcpLoggerMiddleware({ logger: mockLogger, projectId: 'test-project' }))
+      app.get('/', (c) => {
+        const log = getRequestLogger() as unknown as typeof mockLogger
+        return c.json({ hasContext: Object.keys(log?.contextData ?? {}).length > 0 })
+      })
+
+      const res = await app.request('/', {
+        headers: {
+          'X-Cloud-Trace-Context': '105445aa7843bc8bf206b12000100000/1;o=1',
+        },
+      })
+
+      const body = await res.json()
+      expect(body.hasContext).toBe(true)
+    })
+  })
+
+  describe('Hono Context 設定', () => {
+    it('應該在 Hono context 中設定 requestId 和 traceId', async () => {
+      const mockLogger = createMockLogger()
+
+      type Env = {
+        Variables: {
+          requestId: string
+          traceId: string
+        }
+      }
+
+      const app = new Hono<Env>()
+
+      app.use('*', gcpLoggerMiddleware({ logger: mockLogger, projectId: 'test-project' }))
+      app.get('/', (c) => {
+        return c.json({
+          requestId: c.get('requestId'),
+          traceId: c.get('traceId'),
+        })
+      })
+
+      const res = await app.request('/', {
+        headers: {
+          'X-Cloud-Trace-Context': '105445aa7843bc8bf206b12000100000/1;o=1',
+          'X-Request-ID': 'my-request-id',
+        },
+      })
+
+      const body = await res.json()
+      expect(body.requestId).toBe('my-request-id')
+      expect(body.traceId).toBe('105445aa7843bc8bf206b12000100000')
+    })
+  })
+
+  describe('非同步操作中的 Context 傳播', () => {
+    it('應該在 async/await 中保持 context', async () => {
+      const mockLogger = createMockLogger()
+      const app = new Hono()
+
+      app.use('*', gcpLoggerMiddleware({ logger: mockLogger, projectId: 'test-project' }))
+      app.get('/', async (c) => {
+        const beforeAwait = getTraceContext()?.traceId
+
+        await new Promise((resolve) => setTimeout(resolve, 10))
+
+        const afterAwait = getTraceContext()?.traceId
+
+        return c.json({ beforeAwait, afterAwait, same: beforeAwait === afterAwait })
+      })
+
+      const res = await app.request('/', {
+        headers: {
+          'X-Cloud-Trace-Context': '105445aa7843bc8bf206b12000100000/1;o=1',
+        },
+      })
+
+      const body = await res.json()
+      expect(body.same).toBe(true)
+      expect(body.beforeAwait).toBe('105445aa7843bc8bf206b12000100000')
+      expect(body.afterAwait).toBe('105445aa7843bc8bf206b12000100000')
+    })
+
+    it('應該在 Promise.all 中保持 context', async () => {
+      const mockLogger = createMockLogger()
+      const app = new Hono()
+
+      app.use('*', gcpLoggerMiddleware({ logger: mockLogger, projectId: 'test-project' }))
+      app.get('/', async (c) => {
+        const results = await Promise.all([
+          (async () => {
+            await new Promise((resolve) => setTimeout(resolve, 5))
+            return getTraceContext()?.traceId
+          })(),
+          (async () => {
+            await new Promise((resolve) => setTimeout(resolve, 10))
+            return getTraceContext()?.traceId
+          })(),
+        ])
+
+        return c.json({ results, allSame: results.every((r) => r === results[0]) })
+      })
+
+      const res = await app.request('/', {
+        headers: {
+          'X-Cloud-Trace-Context': '105445aa7843bc8bf206b12000100000/1;o=1',
+        },
+      })
+
+      const body = await res.json()
+      expect(body.allSame).toBe(true)
+      expect(body.results[0]).toBe('105445aa7843bc8bf206b12000100000')
+    })
+  })
+
+  describe('錯誤處理', () => {
+    it('在錯誤發生時 handler 內仍應能取得 context', async () => {
+      const mockLogger = createMockLogger()
+      const app = new Hono()
+
+      let capturedTraceId: string | undefined
+
+      app.use('*', gcpLoggerMiddleware({ logger: mockLogger, projectId: 'test-project' }))
+      app.get('/', (c) => {
+        try {
+          capturedTraceId = getTraceContext()?.traceId
+          throw new Error('Test error')
+        } catch {
+          return c.text('Error handled', 500)
+        }
+      })
+
+      const res = await app.request('/', {
+        headers: {
+          'X-Cloud-Trace-Context': '105445aa7843bc8bf206b12000100000/1;o=1',
+        },
+      })
+
+      expect(res.status).toBe(500)
+      expect(capturedTraceId).toBe('105445aa7843bc8bf206b12000100000')
+    })
+  })
+
+  describe('多重請求隔離', () => {
+    it('並行請求應有各自獨立的 context', async () => {
+      const mockLogger = createMockLogger()
+      const app = new Hono()
+
+      app.use('*', gcpLoggerMiddleware({ logger: mockLogger, projectId: 'test-project' }))
+      app.get('/delay', async (c) => {
+        const delay = parseInt(c.req.query('ms') ?? '0', 10)
+        await new Promise((resolve) => setTimeout(resolve, delay))
+        return c.json({ traceId: getTraceContext()?.traceId })
+      })
+
+      const [res1, res2] = await Promise.all([
+        app.request('/delay?ms=20', {
+          headers: { 'X-Cloud-Trace-Context': 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/1;o=1' },
+        }),
+        app.request('/delay?ms=10', {
+          headers: { 'X-Cloud-Trace-Context': 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/2;o=1' },
+        }),
+      ])
+
+      const body1 = await res1.json()
+      const body2 = await res2.json()
+
+      expect(body1.traceId).toBe('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+      expect(body2.traceId).toBe('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')
+    })
+  })
+})

--- a/src/middleware/hono/index.ts
+++ b/src/middleware/hono/index.ts
@@ -1,0 +1,74 @@
+import type { MiddlewareHandler } from 'hono'
+import type { ILogLayer } from 'loglayer'
+import {
+  parseCloudTraceHeader,
+  formatTraceField,
+  generateRequestId,
+  generateTraceId,
+  runWithRequestContext,
+} from '../../context'
+import type { TraceContext, RequestStore } from '../../context'
+
+const GCP_TRACE_HEADER = 'X-Cloud-Trace-Context'
+const REQUEST_ID_HEADER = 'X-Request-ID'
+
+export interface GcpLoggerMiddlewareOptions {
+  logger: ILogLayer
+  projectId?: string
+}
+
+/**
+ * 建立 GCP Logger Middleware for Hono
+ *
+ * 自動擷取 X-Cloud-Trace-Context header 並透過 AsyncLocalStorage 傳播至 logger
+ * 使日誌在 GCP Cloud Logging 中能正確關聯
+ *
+ * @see https://cloud.google.com/trace/docs/trace-context
+ * @see https://cloud.google.com/logging/docs/view/correlate-logs
+ */
+export function gcpLoggerMiddleware(
+  options: GcpLoggerMiddlewareOptions
+): MiddlewareHandler {
+  const { logger } = options
+
+  return async (c, next) => {
+    const projectId =
+      options.projectId ??
+      process.env.GOOGLE_CLOUD_PROJECT ??
+      process.env.GCLOUD_PROJECT ??
+      'unknown-project'
+
+    const traceHeader = c.req.header(GCP_TRACE_HEADER)
+    const existingRequestId = c.req.header(REQUEST_ID_HEADER)
+
+    const parsedTrace = parseCloudTraceHeader(traceHeader)
+
+    const trace: TraceContext = {
+      traceId: parsedTrace?.traceId ?? generateTraceId(),
+      spanId: parsedTrace?.spanId ?? '0',
+      requestId: existingRequestId ?? generateRequestId(),
+      traceSampled: parsedTrace?.traceSampled ?? false,
+    }
+
+    const contextLogger = logger.withContext({
+      'logging.googleapis.com/trace': formatTraceField(projectId, trace.traceId),
+      'logging.googleapis.com/spanId': trace.spanId,
+      'logging.googleapis.com/trace_sampled': trace.traceSampled,
+      requestId: trace.requestId,
+    })
+
+    const store: RequestStore = {
+      trace,
+      logger: contextLogger,
+    }
+
+    c.set('requestId', trace.requestId)
+    c.set('traceId', trace.traceId)
+
+    c.header(REQUEST_ID_HEADER, trace.requestId)
+
+    await runWithRequestContext(store, () => next())
+  }
+}
+
+export type { GcpLoggerMiddlewareOptions as MiddlewareOptions }

--- a/src/middleware/hono/index.ts
+++ b/src/middleware/hono/index.ts
@@ -30,14 +30,13 @@ export function gcpLoggerMiddleware(
   options: GcpLoggerMiddlewareOptions
 ): MiddlewareHandler {
   const { logger } = options
+  const projectId =
+    options.projectId ??
+    process.env.GOOGLE_CLOUD_PROJECT ??
+    process.env.GCLOUD_PROJECT ??
+    'unknown-project'
 
   return async (c, next) => {
-    const projectId =
-      options.projectId ??
-      process.env.GOOGLE_CLOUD_PROJECT ??
-      process.env.GCLOUD_PROJECT ??
-      'unknown-project'
-
     const traceHeader = c.req.header(GCP_TRACE_HEADER)
     const existingRequestId = c.req.header(REQUEST_ID_HEADER)
 

--- a/src/middleware/hono/integration.test.ts
+++ b/src/middleware/hono/integration.test.ts
@@ -5,26 +5,14 @@ import { gcpLoggerMiddleware } from './index'
 
 describe('Hono Middleware 整合測試（使用真實 LogLayer）', () => {
   let originalEnv: NodeJS.ProcessEnv
-  let capturedLogs: string[] = []
-  let originalStdoutWrite: typeof process.stdout.write
 
   beforeEach(() => {
     originalEnv = { ...process.env }
     process.env.NODE_ENV = 'development'
-    capturedLogs = []
-
-    originalStdoutWrite = process.stdout.write.bind(process.stdout)
-    process.stdout.write = ((chunk: string | Uint8Array) => {
-      if (typeof chunk === 'string') {
-        capturedLogs.push(chunk)
-      }
-      return true
-    }) as typeof process.stdout.write
   })
 
   afterEach(() => {
     process.env = originalEnv
-    process.stdout.write = originalStdoutWrite
     vi.restoreAllMocks()
   })
 

--- a/src/middleware/hono/integration.test.ts
+++ b/src/middleware/hono/integration.test.ts
@@ -1,0 +1,320 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { Hono } from 'hono'
+import { createLogger, getRequestLogger, getTraceContext } from '../../index'
+import { gcpLoggerMiddleware } from './index'
+
+describe('Hono Middleware 整合測試（使用真實 LogLayer）', () => {
+  let originalEnv: NodeJS.ProcessEnv
+  let capturedLogs: string[] = []
+  let originalStdoutWrite: typeof process.stdout.write
+
+  beforeEach(() => {
+    originalEnv = { ...process.env }
+    process.env.NODE_ENV = 'development'
+    capturedLogs = []
+
+    originalStdoutWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      if (typeof chunk === 'string') {
+        capturedLogs.push(chunk)
+      }
+      return true
+    }) as typeof process.stdout.write
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    process.stdout.write = originalStdoutWrite
+    vi.restoreAllMocks()
+  })
+
+  describe('端到端請求流程', () => {
+    it('應該在完整請求中正確傳播 trace context', async () => {
+      const logger = createLogger()
+      const app = new Hono()
+
+      app.use('*', gcpLoggerMiddleware({
+        logger,
+        projectId: 'test-project',
+      }))
+
+      app.get('/test', async (c) => {
+        const log = getRequestLogger()
+        const trace = getTraceContext()
+
+        expect(log).toBeDefined()
+        expect(trace).toBeDefined()
+        expect(trace?.traceId).toBe('abcdef12345678901234567890abcdef')
+        expect(trace?.spanId).toBe('12345')
+        expect(trace?.requestId).toBe('custom-request-id')
+
+        log?.info('整合測試日誌')
+
+        return c.json({
+          success: true,
+          traceId: trace?.traceId,
+          requestId: trace?.requestId,
+        })
+      })
+
+      const res = await app.request('/test', {
+        headers: {
+          'X-Cloud-Trace-Context': 'abcdef12345678901234567890abcdef/12345;o=1',
+          'X-Request-ID': 'custom-request-id',
+        },
+      })
+
+      expect(res.status).toBe(200)
+
+      const body = await res.json()
+      expect(body.success).toBe(true)
+      expect(body.traceId).toBe('abcdef12345678901234567890abcdef')
+      expect(body.requestId).toBe('custom-request-id')
+
+      expect(res.headers.get('X-Request-ID')).toBe('custom-request-id')
+    })
+
+    it('應該在多層 async 呼叫中保持 context', async () => {
+      const logger = createLogger()
+      const app = new Hono()
+
+      const traceIds: (string | undefined)[] = []
+
+      async function level1() {
+        traceIds.push(getTraceContext()?.traceId)
+        await new Promise((r) => setTimeout(r, 5))
+        await level2()
+      }
+
+      async function level2() {
+        traceIds.push(getTraceContext()?.traceId)
+        await new Promise((r) => setTimeout(r, 5))
+        await level3()
+      }
+
+      async function level3() {
+        traceIds.push(getTraceContext()?.traceId)
+        getRequestLogger()?.info('深層巢狀呼叫')
+      }
+
+      app.use('*', gcpLoggerMiddleware({ logger, projectId: 'test-project' }))
+
+      app.get('/nested', async (c) => {
+        traceIds.push(getTraceContext()?.traceId)
+        await level1()
+        return c.json({ traceIds })
+      })
+
+      const res = await app.request('/nested', {
+        headers: {
+          'X-Cloud-Trace-Context': '11111111111111111111111111111111/1;o=1',
+        },
+      })
+
+      const body = await res.json()
+
+      expect(body.traceIds).toHaveLength(4)
+      expect(body.traceIds.every((id: string) => id === '11111111111111111111111111111111')).toBe(true)
+    })
+
+    it('並行請求應有完全隔離的 context', async () => {
+      const logger = createLogger()
+      const app = new Hono()
+
+      app.use('*', gcpLoggerMiddleware({ logger, projectId: 'test-project' }))
+
+      app.get('/slow', async (c) => {
+        const initialTrace = getTraceContext()?.traceId
+        const delay = parseInt(c.req.query('delay') ?? '0', 10)
+
+        await new Promise((r) => setTimeout(r, delay))
+
+        const afterDelayTrace = getTraceContext()?.traceId
+
+        getRequestLogger()?.info(`請求完成，延遲 ${delay}ms`)
+
+        return c.json({
+          initialTrace,
+          afterDelayTrace,
+          same: initialTrace === afterDelayTrace,
+        })
+      })
+
+      const [res1, res2, res3] = await Promise.all([
+        app.request('/slow?delay=30', {
+          headers: { 'X-Cloud-Trace-Context': 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/1;o=1' },
+        }),
+        app.request('/slow?delay=20', {
+          headers: { 'X-Cloud-Trace-Context': 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/2;o=1' },
+        }),
+        app.request('/slow?delay=10', {
+          headers: { 'X-Cloud-Trace-Context': 'cccccccccccccccccccccccccccccccc/3;o=1' },
+        }),
+      ])
+
+      const body1 = await res1.json()
+      const body2 = await res2.json()
+      const body3 = await res3.json()
+
+      expect(body1.initialTrace).toBe('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+      expect(body1.afterDelayTrace).toBe('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+      expect(body1.same).toBe(true)
+
+      expect(body2.initialTrace).toBe('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')
+      expect(body2.afterDelayTrace).toBe('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')
+      expect(body2.same).toBe(true)
+
+      expect(body3.initialTrace).toBe('cccccccccccccccccccccccccccccccc')
+      expect(body3.afterDelayTrace).toBe('cccccccccccccccccccccccccccccccc')
+      expect(body3.same).toBe(true)
+    })
+  })
+
+  describe('Logger withContext 驗證', () => {
+    it('getRequestLogger 應回傳已注入 GCP 欄位的 logger', async () => {
+      const logger = createLogger()
+      const app = new Hono()
+
+      let loggerInstance: ReturnType<typeof getRequestLogger>
+
+      app.use('*', gcpLoggerMiddleware({ logger, projectId: 'my-project' }))
+
+      app.get('/check-logger', (c) => {
+        loggerInstance = getRequestLogger()
+        return c.text('OK')
+      })
+
+      await app.request('/check-logger', {
+        headers: {
+          'X-Cloud-Trace-Context': 'fedcba98765432100123456789abcdef/999;o=1',
+        },
+      })
+
+      expect(loggerInstance).toBeDefined()
+    })
+  })
+
+  describe('錯誤情境', () => {
+    it('當沒有 trace header 時應自動產生有效的 traceId', async () => {
+      const logger = createLogger()
+      const app = new Hono()
+
+      app.use('*', gcpLoggerMiddleware({ logger, projectId: 'test-project' }))
+
+      app.get('/no-trace', (c) => {
+        const trace = getTraceContext()
+        return c.json({
+          hasTraceId: !!trace?.traceId,
+          traceIdLength: trace?.traceId?.length,
+          isValidHex: /^[0-9a-f]{32}$/.test(trace?.traceId ?? ''),
+        })
+      })
+
+      const res = await app.request('/no-trace')
+      const body = await res.json()
+
+      expect(body.hasTraceId).toBe(true)
+      expect(body.traceIdLength).toBe(32)
+      expect(body.isValidHex).toBe(true)
+    })
+
+    it('當 trace header 格式錯誤時應優雅處理', async () => {
+      const logger = createLogger()
+      const app = new Hono()
+
+      app.use('*', gcpLoggerMiddleware({ logger, projectId: 'test-project' }))
+
+      app.get('/bad-trace', (c) => {
+        const trace = getTraceContext()
+        return c.json({
+          hasTraceId: !!trace?.traceId,
+          isValidHex: /^[0-9a-f]{32}$/.test(trace?.traceId ?? ''),
+        })
+      })
+
+      const res = await app.request('/bad-trace', {
+        headers: {
+          'X-Cloud-Trace-Context': 'this-is-not-valid',
+        },
+      })
+
+      const body = await res.json()
+
+      expect(body.hasTraceId).toBe(true)
+      expect(body.isValidHex).toBe(true)
+    })
+
+    it('handler 拋出錯誤時 context 仍應可用', async () => {
+      const logger = createLogger()
+      const app = new Hono()
+
+      let errorHandlerTraceId: string | undefined
+
+      app.use('*', gcpLoggerMiddleware({ logger, projectId: 'test-project' }))
+
+      app.get('/error', (c) => {
+        try {
+          errorHandlerTraceId = getTraceContext()?.traceId
+          throw new Error('Intentional error')
+        } catch {
+          getRequestLogger()?.error('捕獲到錯誤')
+          return c.text('Error caught', 500)
+        }
+      })
+
+      const res = await app.request('/error', {
+        headers: {
+          'X-Cloud-Trace-Context': 'e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1/1;o=1',
+        },
+      })
+
+      expect(res.status).toBe(500)
+      expect(errorHandlerTraceId).toBe('e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1')
+    })
+  })
+
+  describe('環境變數整合', () => {
+    it('應該從 GOOGLE_CLOUD_PROJECT 取得 projectId', async () => {
+      process.env.GOOGLE_CLOUD_PROJECT = 'env-project-123'
+
+      const logger = createLogger()
+      const app = new Hono()
+
+      let capturedLogger: ReturnType<typeof getRequestLogger>
+
+      app.use('*', gcpLoggerMiddleware({ logger }))
+
+      app.get('/env-test', (c) => {
+        capturedLogger = getRequestLogger()
+        return c.text('OK')
+      })
+
+      await app.request('/env-test', {
+        headers: {
+          'X-Cloud-Trace-Context': '12345678901234567890123456789012/1;o=1',
+        },
+      })
+
+      expect(capturedLogger).toBeDefined()
+    })
+
+    it('應該優先使用明確傳入的 projectId', async () => {
+      process.env.GOOGLE_CLOUD_PROJECT = 'env-project'
+
+      const logger = createLogger()
+      const app = new Hono()
+
+      app.use('*', gcpLoggerMiddleware({
+        logger,
+        projectId: 'explicit-project',
+      }))
+
+      app.get('/explicit-test', (c) => {
+        return c.text('OK')
+      })
+
+      const res = await app.request('/explicit-test')
+      expect(res.status).toBe(200)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- 新增 Hono middleware 自動解析 `X-Cloud-Trace-Context` header，解決 GCP Cloud Run 上日誌無法正確關聯的問題
- 使用 AsyncLocalStorage 管理請求級別的 trace context
- 新增 `getRequestLogger()` 和 `getTraceContext()` API

## 變更內容

### 核心功能
- `src/context.ts` - AsyncLocalStorage 管理、trace header 解析
- `src/middleware/hono/index.ts` - Hono middleware 實作

### 測試
- 59 個測試全部通過
- 涵蓋 trace header 解析、middleware 行為、整合測試

### 文件
- README 更新為繁體中文，精簡 Hono 使用說明
- 新增 AGENTS.md 專案指引

### 範例
- `examples/hono-server.ts` - 測試伺服器
- `examples/deploy-to-cloudrun.sh` - Cloud Run 部署腳本

## 驗證

已在真實 GCP Cloud Run 環境驗證：
- trace 欄位正確設定
- 同一請求的多個日誌正確關聯

Closes #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增 Hono 框架集成中间件并对外提供 Hono 支持，带请求级跟踪与自动日志绑定
  * 提供示例服务器与本地验证脚本，便于快速试用与测试
  * 添加 Docker 启动支持和 Cloud Run 一键部署脚本

* **文档**
  * 大幅重写 README（改为繁体中文）并新增 AGENTS 开发/架构文档

* **测试**
  * 增加大量单元及集成测试，覆盖上下文传播与并发隔离

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->