### PR TITLE
docs: 修正 LogLayer API 用法及 GitHub Packages 安裝說明

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@
 此套件發布於 GitHub Packages，需先配置 npm registry：
 
 ```bash
-# 1. 在專案目錄建立 .npmrc
-echo "@taiwanta:registry=https://npm.pkg.github.com" >> .npmrc
+# 1. 配置 @taiwanta scope 的 registry
+npm config set @taiwanta:registry https://npm.pkg.github.com
 
 # 2. 安裝套件
 npm install @taiwanta/js-gcp-logger

--- a/README.md
+++ b/README.md
@@ -13,9 +13,17 @@
 
 ## 安裝
 
+此套件發布於 GitHub Packages，需先配置 npm registry：
+
 ```bash
+# 1. 在專案目錄建立 .npmrc
+echo "@taiwanta:registry=https://npm.pkg.github.com" >> .npmrc
+
+# 2. 安裝套件
 npm install @taiwanta/js-gcp-logger
 ```
+
+> **注意**：若需認證，請參考 [GitHub Packages 文件](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry#authenticating-to-github-packages)
 
 ## 快速開始
 

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -9,11 +9,11 @@ logger.debug('Debug information')
 logger.warn('Warning message')
 
 // Logging with metadata
-logger.info('User action', {
+logger.withMetadata({
   userId: '12345',
   action: 'login',
   timestamp: new Date().toISOString()
-})
+}).info('User action')
 
 // Logging errors
 try {

--- a/examples/hono-server.ts
+++ b/examples/hono-server.ts
@@ -82,11 +82,11 @@ app.get('/log-test', (c) => {
   log?.info('這是 info 級別日誌')
   log?.warn('這是 warn 級別日誌')
 
-  log?.info('帶有 metadata 的日誌', {
+  log?.withMetadata({
     userId: 'user-123',
     action: 'test',
     timestamp: new Date().toISOString(),
-  })
+  }).info('帶有 metadata 的日誌')
 
   return c.json({
     message: '已輸出多個日誌，請檢查終端機輸出',


### PR DESCRIPTION
## Summary

- 修正 `examples/basic.js` 和 `examples/hono-server.ts` 中的 LogLayer API 錯誤用法
- 修正 `README.md` 中 GitHub Packages 安裝說明

## 問題

LogLayer 不支援 `logger.info(msg, data)` 語法，此寫法會導致輸出變成 `"訊息 [object Object]"`。

## 解決方案

使用正確的 LogLayer API：
- `logger.withMetadata({ key: value }).info('訊息')` - 附加 metadata
- `logger.withError(error).error('錯誤訊息')` - 附加錯誤

## 變更內容

| 檔案 | 變更 |
|------|------|
| `README.md` | 新增 GitHub Packages registry 配置說明 |
| `examples/basic.js` | 修正 `logger.info('User action', {...})` → `logger.withMetadata({...}).info('User action')` |
| `examples/hono-server.ts` | 修正 `log?.info('帶有 metadata 的日誌', {...})` → `log?.withMetadata({...}).info('帶有 metadata 的日誌')` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **文档**
  * 添加了 GitHub Packages 发布配置指南和认证文档链接

* **API 变更**
  * 日志记录的元数据设置现采用构建器模式调用，改善了代码可读性和灵活性

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->