### PR TITLE
chore: 新增 Dependabot 設定並移除誤加的 ci 套件

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+# Dependabot 自動更新設定
+# 文件：https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # npm 依賴更新
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Asia/Taipei"
+    # 限制同時開啟的 PR 數量
+    open-pull-requests-limit: 10
+    # PR 標籤
+    labels:
+      - "dependencies"
+    # 提交訊息前綴
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(dev-deps)"
+    # 忽略開發依賴
+    ignore:
+      - dependency-name: "*"
+        dependency-type: "development"
+    # 依版本更新類型分組，減少 PR 數量
+    groups:
+      # 生產依賴：loglayer 相關套件一起更新
+      loglayer:
+        patterns:
+          - "loglayer"
+          - "@loglayer/*"
+      # 生產依賴：GCP 相關套件一起更新
+      gcp:
+        patterns:
+          - "@google-cloud/*"
+
+  # GitHub Actions 更新
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Asia/Taipei"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,10 @@ updates:
       gcp:
         patterns:
           - "@google-cloud/*"
+      # 其餘生產依賴（pino、serialize-error 等）
+      other-prod-deps:
+        patterns:
+          - "*"
 
   # GitHub Actions 更新
   - package-ecosystem: "github-actions"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@google-cloud/pino-logging-gcp-config": "^1.3.1",
         "@loglayer/transport-pino": "^2.2.17",
         "@loglayer/transport-simple-pretty-terminal": "^2.3.1",
-        "ci": "^2.3.0",
         "loglayer": "^8.4.0",
         "pino": "^10.1.0",
         "serialize-error": "^12.0.0"
@@ -1556,18 +1555,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/ci": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/ci/-/ci-2.3.0.tgz",
-      "integrity": "sha512-0MGXkzJKkwV3enG7RUxjJKdiAkbaZ7visCjitfpCN2BQjv02KGRMxCHLv4RPokkjJ4xR33FLMAXweS+aQ0pFSQ==",
-      "license": "MIT",
-      "bin": {
-        "ci": "dist/cli.js"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/ci?sponsor=1"
-      }
-    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -2569,6 +2556,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2656,6 +2644,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@google-cloud/pino-logging-gcp-config": "^1.3.1",
     "@loglayer/transport-pino": "^2.2.17",
     "@loglayer/transport-simple-pretty-terminal": "^2.3.1",
-    "ci": "^2.3.0",
     "loglayer": "^8.4.0",
     "pino": "^10.1.0",
     "serialize-error": "^12.0.0"


### PR DESCRIPTION
## Summary

- 新增 `.github/dependabot.yml` 設定，自動追蹤生產依賴與 GitHub Actions 的版本更新
  - 每週一（台北時區）檢查更新
  - 生產依賴按 loglayer / GCP 分組，減少 PR 數量
  - 忽略開發依賴（不影響使用者，手動更新即可）
- 移除 `package.json` 中誤加的 `ci` 套件（疑似誤執行 `npm install ci`）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **Chores**
  * 添加自动化依赖更新配置，按周在亚洲/台北时间运行，支持 npm 与 GitHub Actions 的分组批量更新、标签与规范化提交消息，并限制并发打开的更新 PR 数量。

* **Dependencies**
  * 从依赖中移除 `ci` 包。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->