### PR TITLE
fix(ci): publish workflow 從 tag 同步版本並回寫 main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,13 +8,21 @@ on:
 
 permissions:
   id-token: write  # Required for OIDC
-  contents: read
+  contents: write  # Required for pushing version back to main
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      - name: Extract version from tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_ENV"
+
+      - name: Sync package.json version with tag
+        if: env.VERSION
+        run: npm version "$VERSION" --no-git-tag-version --allow-same-version
 
       - uses: oven-sh/setup-bun@v2
 
@@ -27,3 +35,14 @@ jobs:
       - run: bun run build
       - run: bun test
       - run: npm publish
+
+      - name: Push updated version to main
+        if: env.VERSION
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin main
+          git checkout main
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+          git add package.json
+          git diff --cached --quiet || (git commit -m "chore: bump version to v$VERSION" && git push origin main)


### PR DESCRIPTION
## Summary

- 從 git tag 擷取版本號，在 build/publish 前同步至 package.json
- publish 成功後，將更新後的版本回寫 main 分支
- `workflow_dispatch` 觸發時版本相關步驟自動跳過

## Changes

| 項目 | 修改 |
|---|---|
| `permissions.contents` | `read` → `write` |
| **Extract version from tag** | `refs/tags/v1.2.3` → `1.2.3` |
| **Sync package.json version** | `npm version` 同步版本 |
| **Push updated version to main** | checkout main → update → commit & push |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **改进**
  * 优化了发布工作流，实现了版本管理的自动化。增强了版本同步机制，确保发布流程更加可靠和一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->